### PR TITLE
セミコロンのつけ忘れに注意しましょう

### DIFF
--- a/js/func.js
+++ b/js/func.js
@@ -196,7 +196,7 @@
 
         var $pslist = $('#pslist');
         $pslist.empty();
-        $pslist.append(loc)
+        $pslist.append(loc);
         $pslist.listview();
         $pslist.listview('refresh');
     };


### PR DESCRIPTION
> コードのセミコロンを省き, セミコロンの挿入を処理系に任せた場合, 非常にデバッグが困難な問題が起こります. 決してセミコロンを省くべきではありません.
> <cite>引用元: [Google JavaScript Style Guide 和訳](http://cou929.nu/data/google_javascript_style_guide/#id8)</cite>
